### PR TITLE
fix: grant contents:write permission for gh-pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- CIの`Publish test report`ステップで`github-actions[bot]`が`gh-pages`ブランチへpushする際に403エラーが発生していた
- 原因: トップレベルの`permissions`で`contents: read`になっており、書き込み権限がなかった
- `contents: write`に変更することで修正

## Test plan

- [ ] CIの`test`ジョブが最後まで完走し、`gh-pages`へのpushが成功することを確認

https://claude.ai/code/session_01W984TcuPXr8inWSxDmtwfe
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W984TcuPXr8inWSxDmtwfe)_