### PR TITLE
feat: add linux/arm64 to docker buildx build platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,12 @@ jobs:
             echo "Image already exists, skipping push."
             exit 0
           fi
-          docker buildx create --name builder --use --platform linux/amd64
+          docker buildx create --name builder --use --platform linux/amd64,linux/arm64
           # 失敗時に最後の出力を summary に残す
           set +e
           docker buildx build --builder builder \
             --progress=plain \
+            --platform linux/amd64,linux/arm64 \
             --target dev_runtime \
             -t "kirimaru/fastapi-practice_dev-runtime:${RUNTIME_TAG}" \
             --output type=image,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true,push=true \


### PR DESCRIPTION
## Summary

- `docker buildx create` と `docker buildx build` の `--platform` に `linux/arm64` を追加
- これにより `dev-runtime` イメージが amd64/arm64 のマルチプラットフォームイメージとしてビルド・pushされる

## Test plan

- [ ] CIの `build` ジョブが完走し、DockerHub に `linux/amd64` と `linux/arm64` 両方のマニフェストが含まれることを確認

https://claude.ai/code/session_01W984TcuPXr8inWSxDmtwfe

---
_Generated by [Claude Code](https://claude.ai/code/session_01W984TcuPXr8inWSxDmtwfe)_